### PR TITLE
Favorite recipe

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
         <input class="search-input idea-input" type="text" placeholder="Search by Recipe or Ingredient"></input>
         <button class="search-btn" type="button" name="button"><img src="../images/search.svg" alt="search button"></button>
       </div>
-      <button class="search-btn" type="button" name="button">My Recipes</button>
+      <button class="search-btn saved-recipes-btn" type="button" name="button">My Recipes</button>
       <button class="search-btn" type="button" name="button">My Pantry</button>
     </header>
     <section class="featured-image">

--- a/src/index.html
+++ b/src/index.html
@@ -30,6 +30,10 @@
       </div>
     </aside>
     <main>
+      <div class="my-recipes-banner">
+        <h1>My Recipes</h1>
+        <button class="show-all-btn">Show All Recipes</button>
+      </div>
     </main>
     <script type="text/javascript" src="../data/users-data.js"></script>
     <script type="text/javascript" src="../data/recipe-data.js"></script>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -2,12 +2,14 @@ let main = document.querySelector('main');
 let tagList = document.querySelector('.tag-list');
 let recipes = [];
 let filterBtn = document.querySelector(".filter-btn");
+let favoriteBtn = document.querySelector(".card-apple-icon");
+let user;
 
 window.addEventListener("load", createCards);
 window.addEventListener("load", findTags);
 window.addEventListener("load", generateUser);
 filterBtn.addEventListener("click", findCheckedBoxes);
-
+main.addEventListener("click", addToMyRecipes);
 
 function createCards() {
   recipeData.forEach(recipe => {
@@ -78,11 +80,18 @@ function hideUnselectedRecipes(filtered) {
 };
 
 function generateUser() {
-  let user = new User(users[Math.floor(Math.random()*users.length)]);
+  user = new User(users[Math.floor(Math.random()*users.length)]);
   let firstName = user.name.split(' ')[0];
   let welcomeMsg = `
     <div class="welcome-msg">
       <h1>Welcome ${firstName}!</h1>
     </div>`;
   main.insertAdjacentHTML("afterbegin", welcomeMsg);
+}
+
+function addToMyRecipes() {
+  if (event.target.className === "card-apple-icon") {
+    user.saveRecipe(event.target.closest(".recipe-card").id);
+    console.log(user.favoriteRecipes)
+  }
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -80,8 +80,6 @@ function hideUnselectedRecipes(filtered) {
   let foundRecipes = recipes.filter(recipe => {
     return !filtered.includes(recipe);
   });
-  console.log(filtered)
-  console.log(foundRecipes)
   foundRecipes.forEach(recipe => {
     let domRecipe = document.getElementById(`${recipe.id}`);
     domRecipe.style.display = "none";
@@ -119,4 +117,11 @@ function showSavedRecipes() {
     let domRecipe = document.getElementById(`${recipe.id}`);
     domRecipe.style.display = "none";
   });
+  showMyRecipesBanner();
+}
+
+function showMyRecipesBanner() {
+  document.querySelector(".welcome-msg").style.display = "none";
+  document.querySelector(".my-recipes-banner").style.display = "flex";
+
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -2,7 +2,7 @@ let main = document.querySelector('main');
 let tagList = document.querySelector('.tag-list');
 let recipes = [];
 let filterBtn = document.querySelector(".filter-btn");
-let favoriteBtn = document.querySelector(".card-apple-icon");
+let savedRecipesBtn = document.querySelector(".saved-recipes-btn");
 let user;
 
 window.addEventListener("load", createCards);
@@ -10,6 +10,7 @@ window.addEventListener("load", findTags);
 window.addEventListener("load", generateUser);
 filterBtn.addEventListener("click", findCheckedBoxes);
 main.addEventListener("click", addToMyRecipes);
+savedRecipesBtn.addEventListener("click", showSavedRecipes);
 
 function createCards() {
   recipeData.forEach(recipe => {
@@ -91,14 +92,23 @@ function generateUser() {
 
 function addToMyRecipes() {
   if (event.target.className === "card-apple-icon") {
-    let card = event.target.closest(".recipe-card");
-    if (!user.favoriteRecipes.includes(card.id)) {
+    let cardId = parseInt(event.target.closest(".recipe-card").id)
+    if (!user.favoriteRecipes.includes(cardId)) {
       event.target.src = "../images/apple-logo.png";
-      user.saveRecipe(card.id);
+      user.saveRecipe(cardId);
     } else {
       event.target.src = "../images/apple-logo-outline.png";
-      user.removeRecipe(card.id);
-    }
-  }
-  console.log(user.favoriteRecipes)
+      user.removeRecipe(cardId);
+    };
+  };
+}
+
+function showSavedRecipes() {
+  let unsavedRecipes = recipes.filter(recipe => {
+    return !user.favoriteRecipes.includes(recipe.id);
+  });
+  unsavedRecipes.forEach(recipe => {
+    let domRecipe = document.getElementById(`${recipe.id}`);
+    domRecipe.style.display = "none";
+  });
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -91,7 +91,14 @@ function generateUser() {
 
 function addToMyRecipes() {
   if (event.target.className === "card-apple-icon") {
-    user.saveRecipe(event.target.closest(".recipe-card").id);
-    console.log(user.favoriteRecipes)
+    let card = event.target.closest(".recipe-card");
+    if (!user.favoriteRecipes.includes(card.id)) {
+      event.target.src = "../images/apple-logo.png";
+      user.saveRecipe(card.id);
+    } else {
+      event.target.src = "../images/apple-logo-outline.png";
+      user.removeRecipe(card.id);
+    }
   }
+  console.log(user.favoriteRecipes)
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -62,18 +62,26 @@ function findCheckedBoxes() {
 }
 
 function findTaggedRecipes(selected) {
+  let filteredResults = [];
   selected.forEach(tag => {
-    let filteredResults = recipes.filter(recipe => {
+    let allRecipes = recipes.filter(recipe => {
       return recipe.tags.includes(tag.parentNode.innerText.trim());
     });
-    hideUnselectedRecipes(filteredResults);
+    allRecipes.forEach(recipe => {
+      if (!filteredResults.includes(recipe)) {
+        filteredResults.push(recipe);
+      }
+    })
   });
+  hideUnselectedRecipes(filteredResults);
 }
 
 function hideUnselectedRecipes(filtered) {
   let foundRecipes = recipes.filter(recipe => {
     return !filtered.includes(recipe);
   });
+  console.log(filtered)
+  console.log(foundRecipes)
   foundRecipes.forEach(recipe => {
     let domRecipe = document.getElementById(`${recipe.id}`);
     domRecipe.style.display = "none";

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -3,6 +3,7 @@ let tagList = document.querySelector('.tag-list');
 let recipes = [];
 let filterBtn = document.querySelector(".filter-btn");
 let savedRecipesBtn = document.querySelector(".saved-recipes-btn");
+let allRecipesBtn = document.querySelector(".show-all-btn");
 let user;
 
 window.addEventListener("load", createCards);
@@ -11,6 +12,7 @@ window.addEventListener("load", generateUser);
 filterBtn.addEventListener("click", findCheckedBoxes);
 main.addEventListener("click", addToMyRecipes);
 savedRecipesBtn.addEventListener("click", showSavedRecipes);
+allRecipesBtn.addEventListener("click", showAllRecipes);
 
 function createCards() {
   recipeData.forEach(recipe => {
@@ -123,5 +125,17 @@ function showSavedRecipes() {
 function showMyRecipesBanner() {
   document.querySelector(".welcome-msg").style.display = "none";
   document.querySelector(".my-recipes-banner").style.display = "flex";
+}
 
+function showAllRecipes() {
+  recipes.forEach(recipe => {
+    let domRecipe = document.getElementById(`${recipe.id}`);
+    domRecipe.style.display = "block";
+  });
+  showWelcomeBanner();
+}
+
+function showWelcomeBanner() {
+  document.querySelector(".welcome-msg").style.display = "flex";
+  document.querySelector(".my-recipes-banner").style.display = "none";
 }

--- a/src/user.js
+++ b/src/user.js
@@ -9,6 +9,12 @@ class User {
   saveRecipe(recipe) {
     this.favoriteRecipes.push(recipe);
   }
+
+  removeRecipe(recipe) {
+    let i = this.favoriteRecipes.indexOf(recipe);
+    this.favoriteRecipes.splice(i, 1);
+  }
+
   decideToCook(recipe) {
     this.recipesToCook.push(recipe);
   }

--- a/styles.css
+++ b/styles.css
@@ -163,6 +163,7 @@ li {
   margin: 5px;
 }
 
+.show-all-btn,
 .filter-btn {
   background-color: #359567;
   border: 0;
@@ -171,9 +172,16 @@ li {
   font-size: 12pt;
   font-weight: bold;
   color: white;
-  margin-top: 10px;
+  margin-top: 15px;
   padding: 5px 10px 5px 10px;
   cursor: pointer;
+}
+
+.show-all-btn {
+  width: 200px;
+  height: 40px;
+  margin-right: 5%;
+  margin-top:
 }
 
 .filter-btn:hover {
@@ -192,6 +200,7 @@ span {
   color: #C4EB67;
 }
 
+.my-recipes-banner,
 .welcome-msg {
   width: 95%;
   background-color: #84C8A4;
@@ -199,7 +208,13 @@ span {
   text-align: center;
 }
 
+.my-recipes-banner h1,
 .welcome-msg h1 {
   width: 100%;
   margin-top: 10px;
+}
+
+.my-recipes-banner {
+  display: none;
+  justify-content: space-between;
 }

--- a/styles.css
+++ b/styles.css
@@ -135,6 +135,7 @@ main {
   width: 45px;
   padding-bottom: 10px;
   float: right;
+  cursor: pointer;
 }
 
 .header-apple-icon {
@@ -172,6 +173,7 @@ li {
   color: white;
   margin-top: 10px;
   padding: 5px 10px 5px 10px;
+  cursor: pointer;
 }
 
 .filter-btn:hover {


### PR DESCRIPTION
#### What's this PR do?
- When a recipe card's apple icon is clicked, that recipe is added to the user's favorite recipes and the icon changes to a filled in apple
- When the same recipe card's apple icon is clicked again, that recipe is removed from the user's favorite recipes and the icon changes back to an outline of an apple
- If the user clicks the My Recipes button, they will only see the recipe card's that they have favorited.  They will also see a My Recipes banner and a Show All Recipes button.
- If the user clicks the Show All Recipes button, they will once again see all 50 recipes and the welcome banner
- Adds pointer cursors to the buttons
- Fixes glitch in the filter function that happened when a recipe had two or more tags of the checked tags
#### Where should the reviewer start?
On the main page
#### How should this be manually tested?
- Try clicking the apple icon on a few recipes and then clicking the My Recipes button
- Try clicking the Show All Recipes function
- Try clicking the apple icon on a recipe twice - the icon should change back to an outline and the recipe should not show up under My Recipes
- Try filtering appetizer and antipasto recipes - you should no longer get a funky page as a result
#### Any background context you want to provide?
N/A
#### What are the relevant tickets?
#28 
