### PR TITLE
Unfilter recipes

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -48,13 +48,13 @@ function findTags() {
   });
   tags.sort();
   listTags(tags);
+  console.log(tags)
 }
 
 function listTags(allTags) {
   allTags.forEach(tag => {
-    let tagHtml = `<li><input type="checkbox" id="${tag}-checkbox">
-                  <label for="${tag}-checkbox">${tag}</label></li>`
-                  ;
+    let tagHtml = `<li><input type="checkbox" class="checked-tag" id="${tag}-checkbox">
+                  <label for="${tag}-checkbox">${tag}</label></li>`;
     tagList.insertAdjacentHTML('beforeend', tagHtml);
   });
 }
@@ -65,6 +65,7 @@ function findCheckedBoxes() {
   let selectedTags = checkboxInfo.filter(box => {
     return box.checked;
   })
+  console.log(selectedTags)
   findTaggedRecipes(selectedTags);
 }
 
@@ -80,6 +81,8 @@ function findTaggedRecipes(selected) {
       }
     })
   });
+  showAllRecipes();
+  console.log(filteredResults)
   hideUnselectedRecipes(filteredResults);
 }
 
@@ -149,5 +152,4 @@ function searchRecipes() {
   let searchedRecipes = recipeData.filter(recipe => {
     return recipe.name.includes(searchInput.value);
   });
-  console.log(searchedRecipes);
 }

--- a/styles.css
+++ b/styles.css
@@ -110,20 +110,18 @@ h1 {
 
 aside {
   grid-area: aside;
-  background-color: white;
-  position: relative;
   text-align: center;
-  display: flex;
-  justify-content: center;
-  height: 100%gi;
+  position: relative;
 }
 
 main {
   grid-area: main;
   display: flex;
   justify-content: center;
+  align-content: flex-start;
   flex-direction: row;
   flex-wrap: wrap;
+  min-height: 6000px;
 }
 
 .recipe-card {
@@ -162,7 +160,7 @@ main {
 ul {
   list-style-type: none;
   text-align: left;
-  padding: 0;
+  padding-left: 35px;
 }
 
 li {
@@ -178,7 +176,6 @@ li {
   font-size: 12pt;
   font-weight: bold;
   color: white;
-  margin-top: 15px;
   padding: 5px 10px 5px 10px;
   cursor: pointer;
 }
@@ -187,7 +184,7 @@ li {
   width: 200px;
   height: 40px;
   margin-right: 5%;
-  margin-top:
+  margin-top: 15px;
 }
 
 .filter-btn:hover {
@@ -195,10 +192,11 @@ li {
 }
 
 .wrap {
-  margin-top: 15px;
-  width: auto;
+  width: 200px;
   position: fixed;
-  height: 100%
+  height: 100vh;
+  background-color: white;
+  padding: 10px;
 }
 
 span {


### PR DESCRIPTION
#### What's this PR do?
- Fixes glitch that didn't "unhide" recipes each time filter was clicked and rehide them based on the new filter results
- Restyles the filter sidebar so that its background scrolls with the page (not just the sidebar content)
- Sets a min-height to the main section so that the layout doesn't get funky when there are only one or two results
#### Where should the reviewer start?
- On the main page
#### How should this be manually tested?
- Try filtering lunch, then unchecking lunch and filtering by main course. There should be overlap between the filter results.
- Try scrolling while all the recipes are on the page
#### Any background context you want to provide?
N/A
#### What are the relevant tickets?
N/A
