### PR TITLE
Fix broken filter functionality

### DIFF
--- a/data/recipe-data.js
+++ b/data/recipe-data.js
@@ -675,7 +675,7 @@ let recipeData = [
         "instruction": "Remove the loaf from the oven and immediately remove it from the pan (careful it will be hot), and set the loaf on a cooling rack to cool. If you do not remove it right away the steam will make the crust soggy.Slice off the two ends to allow the steam to escape, or it will begin to sink in on the sides and bottom.Once cooled, it will shrink a little bit. Slice it with an electric slicer, electric knife or serrated knife. You'll get about 13-16, depending upon how thick you slice it."
       }
     ],
-    "tags": []
+    "tags": ["side dish"]
   },
   {
     "name": "Ambrosia Cupcakes",

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -66,8 +66,8 @@ function findTags() {
 
 function listTags(allTags) {
   allTags.forEach(tag => {
-    let tagHtml = `<li><input type="checkbox" class="checked-tag" id="${tag}-checkbox">
-                  <label for="${tag}-checkbox">${capitalize(tag)}</label></li>`;
+    let tagHtml = `<li><input type="checkbox" class="checked-tag" id="${tag}">
+                  <label for="${tag}">${capitalize(tag)}</label></li>`;
     tagList.insertAdjacentHTML('beforeend', tagHtml);
   });
 }
@@ -90,8 +90,9 @@ function findCheckedBoxes() {
 function findTaggedRecipes(selected) {
   let filteredResults = [];
   selected.forEach(tag => {
+    console.log(tag)
     let allRecipes = recipes.filter(recipe => {
-      return recipe.tags.includes(tag.parentNode.innerText.trim());
+      return recipe.tags.includes(tag.id);
     });
     allRecipes.forEach(recipe => {
       if (!filteredResults.includes(recipe)) {
@@ -99,6 +100,7 @@ function findTaggedRecipes(selected) {
       }
     })
   });
+  console.log(filteredResults)
   showAllRecipes();
   hideUnselectedRecipes(filteredResults);
 }


### PR DESCRIPTION
#### What's this PR do?
- Fixes the broken filter functionality so that you can once again filter by recipe type
- Adds a recipe type to the only recipe that didn't have one yet
#### Where should the reviewer start?
- Main page
#### How should this be manually tested?
Try to filter by recipe types
#### Any background context you want to provide?
n/a
#### What are the relevant tickets?
n/a
